### PR TITLE
Fix bottom overflow in Browse & Local Library cards on Desktop

### DIFF
--- a/lib/components/playbutton_view/playbutton_card.dart
+++ b/lib/components/playbutton_view/playbutton_card.dart
@@ -158,10 +158,13 @@ class PlaybuttonCard extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        subtitle: Text(
-          unescapeHtml.isEmpty ? "\n" : unescapeHtml,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
+        subtitle: Container(
+          height: 36,
+          child: Text(
+            unescapeHtml.isEmpty ? "\n" : unescapeHtml,
+            maxLines: 2,
+            overflow: TextOverflow.fade,
+          ),
         ),
         onPressed: onTap,
       ),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix bottom overflow in `PlaybuttonCard` by changing subtitle overflow to `TextOverflow.fade` and setting container height.
> 
>   - **UI Fix**:
>     - In `PlaybuttonCard` in `playbutton_card.dart`, changed `subtitle` overflow behavior from `TextOverflow.ellipsis` to `TextOverflow.fade` to fix bottom overflow issue on desktop.
>     - Set `subtitle` container height to 36 to ensure consistent layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dashwave-test%2Fspotube&utm_source=github&utm_medium=referral)<sup> for a7522872fc5dce86e072e62323c22cded5d25af1. You can [customize](https://app.ellipsis.dev/dashwave-test/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->